### PR TITLE
Improve type robustness for `TrackedAsyncData<T>`

### DIFF
--- a/type-tests/tracked-async-data-test.ts
+++ b/type-tests/tracked-async-data-test.ts
@@ -1,19 +1,10 @@
-import TrackedAsyncData from "ember-async-data/tracked-async-data";
+import TrackedAsyncData, {
+  JSONRepr,
+} from "ember-async-data/tracked-async-data";
 import { expectTypeOf } from "expect-type";
 
-expectTypeOf(TrackedAsyncData).toBeConstructibleWith(12);
-expectTypeOf(TrackedAsyncData).toBeConstructibleWith("hello");
-expectTypeOf(TrackedAsyncData).toBeConstructibleWith(true);
-expectTypeOf(TrackedAsyncData).toBeConstructibleWith(null);
-expectTypeOf(TrackedAsyncData).toBeConstructibleWith(undefined);
-expectTypeOf(TrackedAsyncData).toBeConstructibleWith({ cool: "story" });
-expectTypeOf(TrackedAsyncData).toBeConstructibleWith(["neat"]);
-expectTypeOf(TrackedAsyncData).toBeConstructibleWith(Promise.resolve());
-expectTypeOf(TrackedAsyncData).toBeConstructibleWith(Promise.resolve(12));
-expectTypeOf(TrackedAsyncData).toBeConstructibleWith(Promise.reject());
-expectTypeOf(TrackedAsyncData).toBeConstructibleWith(Promise.reject("gah"));
-
 declare class PublicAPI<T> {
+  constructor(data: T | Promise<T>);
   get state(): "PENDING" | "RESOLVED" | "REJECTED";
   get value(): T | null;
   get error(): unknown;
@@ -27,4 +18,45 @@ declare class PublicAPI<T> {
   toString(): string;
 }
 
-expectTypeOf<TrackedAsyncData<string>>().toEqualTypeOf<PublicAPI<string>>();
+expectTypeOf(TrackedAsyncData).toBeConstructibleWith(12);
+expectTypeOf(TrackedAsyncData).toBeConstructibleWith("hello");
+expectTypeOf(TrackedAsyncData).toBeConstructibleWith(true);
+expectTypeOf(TrackedAsyncData).toBeConstructibleWith(null);
+expectTypeOf(TrackedAsyncData).toBeConstructibleWith(undefined);
+expectTypeOf(TrackedAsyncData).toBeConstructibleWith({ cool: "story" });
+expectTypeOf(TrackedAsyncData).toBeConstructibleWith(["neat"]);
+expectTypeOf(TrackedAsyncData).toBeConstructibleWith(Promise.resolve());
+expectTypeOf(TrackedAsyncData).toBeConstructibleWith(Promise.resolve(12));
+expectTypeOf(TrackedAsyncData).toBeConstructibleWith(Promise.reject());
+expectTypeOf(TrackedAsyncData).toBeConstructibleWith(Promise.reject("gah"));
+
+// We use `toMatchTypeOf` here to confirm the union type which makes up
+// `TrackedAsyncData` is structurally compatible with the desired public
+// interface, but then use explicit `toEqualTypeOf` checks on each individual
+// property below to guarantee they don't accidentally widen the actual type
+// of each property.
+declare let data: TrackedAsyncData<string>;
+declare let expected: PublicAPI<string>;
+expectTypeOf(data).toMatchTypeOf(expected);
+
+expectTypeOf(data.state).toEqualTypeOf<"PENDING" | "RESOLVED" | "REJECTED">();
+expectTypeOf(data.value).toEqualTypeOf<string | null>();
+expectTypeOf(data.error).toEqualTypeOf<unknown>();
+expectTypeOf(data.isPending).toEqualTypeOf<boolean>();
+expectTypeOf(data.isResolved).toEqualTypeOf<boolean>();
+expectTypeOf(data.isRejected).toEqualTypeOf<boolean>();
+expectTypeOf(data.toJSON).toBeFunction();
+expectTypeOf(data.toJSON()).toEqualTypeOf<JSONRepr<string>>();
+expectTypeOf(data.toString).toBeFunction();
+expectTypeOf(data.toString()).toEqualTypeOf<string>();
+
+if (data.isPending) {
+  expectTypeOf(data.value).toEqualTypeOf(null);
+  expectTypeOf(data.error).toEqualTypeOf(null);
+} else if (data.isResolved) {
+  expectTypeOf(data.value).toEqualTypeOf<string>();
+  expectTypeOf(data.error).toEqualTypeOf(null);
+} else if (data.isRejected) {
+  expectTypeOf(data.value).toEqualTypeOf(null);
+  expectTypeOf(data.error).toEqualTypeOf<unknown>();
+}


### PR DESCRIPTION
Export a union type as the actual public API of `TrackedAsyncData<T>`, along with a `const`-bound export of the class (with a safe cast for the constructor). The union is implemented as a union of interfaces which extend the base class so that (a) they are guaranteed to be structurally compatible and (b) docstrings continue to "just work".

The upshot of this change: All existing invocations continue to work exactly as they have up to this point, but the type now correctly narrows when checking any of the boolean properties exposed to indicate the state of the type. For example, given a `TrackedAsyncData<string>`, the `.value` and `.error` properties will have the type `null` when `.isPending` is `true`; `.value` will have the type `string` when `.isResolved` is `true` but `.error` will still be `null`, etc.

---

Thanks to @dfreeman for suggesting a variant on this approach!