### PR TITLE
Supply correct types for `state`

### DIFF
--- a/addon/tracked-async-data.ts
+++ b/addon/tracked-async-data.ts
@@ -133,6 +133,7 @@ class _TrackedAsyncData<T> {
   /**
    * The resolution state of the promise.
    */
+  @dependentKeyCompat
   get state(): State<T>["data"][0] {
     return this.#state.data[0];
   }
@@ -267,6 +268,7 @@ export type JSONRepr<T> =
 //     automatically.
 
 interface Pending<T> extends _TrackedAsyncData<T> {
+  state: "PENDING";
   isPending: true;
   isResolved: false;
   isRejected: false;
@@ -275,6 +277,7 @@ interface Pending<T> extends _TrackedAsyncData<T> {
 }
 
 interface Resolved<T> extends _TrackedAsyncData<T> {
+  state: "RESOLVED";
   isPending: false;
   isResolved: true;
   isRejected: false;
@@ -283,6 +286,7 @@ interface Resolved<T> extends _TrackedAsyncData<T> {
 }
 
 interface Rejected<T> extends _TrackedAsyncData<T> {
+  state: "REJECTED";
   isPending: false;
   isResolved: false;
   isRejected: true;

--- a/type-tests/tracked-async-data-test.ts
+++ b/type-tests/tracked-async-data-test.ts
@@ -3,6 +3,8 @@ import TrackedAsyncData, {
 } from "ember-async-data/tracked-async-data";
 import { expectTypeOf } from "expect-type";
 
+declare function unreachable(x: never): never;
+
 declare class PublicAPI<T> {
   constructor(data: T | Promise<T>);
   get state(): "PENDING" | "RESOLVED" | "REJECTED";
@@ -59,4 +61,19 @@ if (data.isPending) {
 } else if (data.isRejected) {
   expectTypeOf(data.value).toEqualTypeOf(null);
   expectTypeOf(data.error).toEqualTypeOf<unknown>();
+} else {
+  unreachable(data);
+}
+
+if (data.state === "PENDING") {
+  expectTypeOf(data.value).toEqualTypeOf(null);
+  expectTypeOf(data.error).toEqualTypeOf(null);
+} else if (data.state === "RESOLVED") {
+  expectTypeOf(data.value).toEqualTypeOf<string>();
+  expectTypeOf(data.error).toEqualTypeOf(null);
+} else if (data.state === "REJECTED") {
+  expectTypeOf(data.value).toEqualTypeOf(null);
+  expectTypeOf(data.error).toEqualTypeOf<unknown>();
+} else {
+  unreachable(data);
 }


### PR DESCRIPTION
As with the `.isPending`, `.isResolved`, and `.isRejected` properties, the value of the `.state` property is known statically, so the exposed types can treat it as a static string.

Additionally, since end users may depend on it in Ember Classic code with dependent keys, like `@computed('someAsyncData.state')`, decorate it with `@dependentKeyCompat`.