### PR TITLE
Fix CI config: on push

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   pull_request:
+  push:
     # filtering branches here prevents duplicate builds from pull_request and push
     branches:
       - main


### PR DESCRIPTION
Run CI also on push to `main`, not only on a pull request.

It *seems* to me the previous config was probably wrong by accident, as there were no CI runs at all for the `main` branch: https://github.com/chriskrycho/ember-async-data/actions/workflows/CI.yml?query=branch%3Amain