### PR TITLE
Chore: only run ember-try suite *once*

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: yarn install --frozen-lockfile --non-interactive
-      - run: yarn test
+      - run: ./node_modules/.bin/ember test
 
   tests_other:
     needs: lint
@@ -51,7 +51,24 @@ jobs:
       - uses: actions/checkout@v2
       - uses: volta-cli/action@v1
       - run: yarn install --frozen-lockfile --non-interactive
-      - run: yarn test
+      - run: ./node_modules/.bin/ember test
+
+  tests_compat:
+    needs: tests_linux
+    name: "Tests: Ember compatibility (ember-source@${{ matrix.node-version }})"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ember-version:
+          ["lts-3.16", "lts-3.20", "lts-24", "release", "beta", "canary"]
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: volta-cli/action@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: yarn install --frozen-lockfile --non-interactive
+      - run: "./node_modules/.bin/ember try:one ember-${{ matrix.ember-version }}"
 
   tests_ts:
     needs: lint

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -60,7 +60,7 @@ jobs:
     strategy:
       matrix:
         ember-version:
-          ["lts-3.16", "lts-3.20", "lts-24", "release", "beta", "canary"]
+          ["lts-3.16", "lts-3.20", "lts-3.24", "release", "beta", "canary"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -55,7 +55,7 @@ jobs:
 
   tests_compat:
     needs: tests_linux
-    name: "Tests: Ember compatibility (ember-source@${{ matrix.node-version }})"
+    name: "Tests: Ember compatibility (ember-source@${{ matrix.ember-version }})"
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -46,6 +46,7 @@ module.exports = async function () {
       },
       {
         name: "ember-beta",
+        allowedToFail: true,
         npm: {
           devDependencies: {
             "ember-source": await getChannelURL("beta"),
@@ -54,6 +55,7 @@ module.exports = async function () {
       },
       {
         name: "ember-canary",
+        allowedToFail: true,
         npm: {
           devDependencies: {
             "ember-source": await getChannelURL("canary"),


### PR DESCRIPTION
Update CI config so we run the ember-try compatibility suite and the TS compatibility suite *only once*, and for the supported OS's run *just* `ember test`.