### PR TITLE
Breaking: drop support for versions of Ember before 3.24 LTS

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -59,8 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ember-version:
-          ["lts-3.16", "lts-3.20", "lts-3.24", "release", "beta", "canary"]
+        ember-version: ["lts-3.24", "release", "beta", "canary"]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Requires #151. Pairs with #149 as a breaking change!