### PR TITLE
Use `finally` for `waiter.endAsync`

### DIFF
--- a/addon/tracked-async-data.ts
+++ b/addon/tracked-async-data.ts
@@ -97,16 +97,14 @@ class _TrackedAsyncData<T> {
 
     // Otherwise, we know that haven't yet handled that promise anywhere in the
     // system, so we continue creating a new instance.
-    promise.then(
-      (value) => {
-        this.#state.data = ["RESOLVED", value];
+    promise
+      .then(
+        (value) => (this.#state.data = ["RESOLVED", value]),
+        (error) => (this.#state.data = ["REJECTED", error])
+      )
+      .finally(() => {
         waiter.endAsync(this.#token);
-      },
-      (error) => {
-        this.#state.data = ["REJECTED", error];
-        waiter.endAsync(this.#token);
-      }
-    );
+      });
 
     TRACKED_PROMISES.set(promise, this);
 


### PR DESCRIPTION
This shouldn't change the semantics at all; it's just a nice win for the clarity and maintainability of the code, and it guarantees that even if we change it (e.g. to re-`throw`) in the future, it will always end the test waiter.

Thanks to @scalvert for the suggestion!