### PR TITLE
Set minimum Ember version to 3.28

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -61,6 +61,7 @@ jobs:
       matrix:
         ember-version:
           - "lts-3.28"
+          - "lts-4.4"
           - "release"
           - "beta"
           - "canary"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -59,7 +59,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ember-version: ["lts-3.24", "release", "beta", "canary"]
+        ember-version:
+          - "lts-3.28"
+          - "release"
+          - "beta"
+          - "canary"
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ A utility/helper and data structure for representing a `Promise` in a declarativ
 
 ## Compatibility
 
-* Ember.js v3.16 or above (requires Octane Edition)
+* Ember.js v3.28 or above (requires Octane Edition)
 * Ember CLI v2.13 or above
 * Node.js v14 or above
 

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -15,6 +15,14 @@ module.exports = async function () {
         },
       },
       {
+        name: "ember-lts-4.4",
+        npm: {
+          devDependencies: {
+            "ember-source": "~4.4.0",
+          },
+        },
+      },
+      {
         name: "ember-release",
         npm: {
           devDependencies: {

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -7,26 +7,10 @@ module.exports = async function () {
     useYarn: true,
     scenarios: [
       {
-        name: "ember-lts-3.16",
+        name: "ember-lts-3.28",
         npm: {
           devDependencies: {
-            "ember-source": "~3.16.0",
-          },
-        },
-      },
-      {
-        name: "ember-lts-3.20",
-        npm: {
-          devDependencies: {
-            "ember-source": "~3.20.0",
-          },
-        },
-      },
-      {
-        name: "ember-lts-3.24",
-        npm: {
-          devDependencies: {
-            "ember-source": "~3.24.0",
+            "ember-source": "~3.28.0",
           },
         },
       },

--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
     "@ember/test-waiters": "^3.0.0",
     "ember-cli-babel": "^7.26.6",
     "ember-cli-htmlbars": "^6.0.0",
-    "ember-cli-typescript": "^5.0.0",
-    "ember-destroyable-polyfill": "^2.0.3"
+    "ember-cli-typescript": "^5.0.0"
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,10 @@
     "edition": "octane"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "versionCompatibility": {
+      "ember": "3.28 || >=4.0"
+    }
   },
   "release-it": {
     "plugins": {


### PR DESCRIPTION
- Add 3.28 LTS to ember-try config.
- Remove versions earlier than 3.28 from CI and support list.
- Update README to specify minimum version