### PR TITLE
Add Glint usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,31 @@ Then callers could use it like this:
 </Loader>
 ```
 
+This project ships [Glint](https://github.com/typed-ember/glint) types,
+which allow you when using TypeScript to get strict type checking in your templates.
+
+Unless you are using [strict mode](http://emberjs.github.io/rfcs/0496-handlebars-strict-mode.html) templates
+(via [first class component templates](http://emberjs.github.io/rfcs/0779-first-class-component-templates.html)),
+Glint needs a [Template Registry](https://typed-ember.gitbook.io/glint/using-glint/ember/template-registry)
+that contains entries for the element modifier provided by this addon.
+To add these registry entries automatically to your app, you just need to import `ember-async-data/template-registry`
+from somewhere in your app. When using Glint already, you will likely have a file like
+`types/glint.d.ts` where you already import glint types, so just add the import there:
+
+```ts
+import '@glint/environment-ember-loose';
+import type SimpleTrackHelperRegistry from 'ember-async-data/template-registry';
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry extends SimpleTrackHelperRegistry, /* other addon registries */ {
+    // local entries
+  }
+}
+```
+
+> **Note:** Glint itself is still under active development, and as such breaking changes might occur.
+> Therefore, Glint support by this addon is also considered experimental, and not covered by our SemVer contract!
+
 ### Testing
 
 Working with the full range of behavior from `TrackedAsyncData` in tests will require you to manage the inherent asynchrony of the system much more explicitly than you may be used to. This is unavoidable: the point of the helper and data type *is* dealing with asynchrony in an explicit way.

--- a/README.md
+++ b/README.md
@@ -418,10 +418,10 @@ from somewhere in your app. When using Glint already, you will likely have a fil
 
 ```ts
 import '@glint/environment-ember-loose';
-import type SimpleTrackHelperRegistry from 'ember-async-data/template-registry';
+import type EmberAsyncDataRegistry from 'ember-async-data/template-registry';
 
 declare module '@glint/environment-ember-loose/registry' {
-  export default interface Registry extends SimpleTrackHelperRegistry, /* other addon registries */ {
+  export default interface Registry extends EmberAsyncDataRegistry, /* other addon registries */ {
     // local entries
   }
 }


### PR DESCRIPTION
this is similar to https://github.com/chriskrycho/ember-simple-track-helper/pull/103/files, except readme of this package has more content and I'm added note to the are seem most suitable.

another option I considered - create a new "Glint" section next to "Usage > In templates"